### PR TITLE
Fix nanoid indefinite-loop vulnerability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11174,9 +11174,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "underscore": "^1.13.8",
     "@tootallnate/once": "^2.0.1",
     "svgo": "^4.0.2",
-    "uuid": "^11.1.1"
+    "uuid": "^11.1.1",
+    "nanoid": "^3.3.17"
   },
   "browserslist": [
     ">0.2%",


### PR DESCRIPTION
## Summary
- New Dependabot alert: `nanoid` <3.3.17 (pulled in transitively via `postcss`) loops indefinitely when a custom generator's size is zero (GHSA-2v37-7h3g-55p8, high).
- Added `nanoid` to the existing `overrides` block (introduced in #38) to pin it to a patched version.
- `npm audit` now reports only the pre-existing `webpack-dev-server` finding, which is dev-server-only and requires replacing `react-scripts` to fully resolve (documented in #38).

## Test plan
- [x] `npm install` completes cleanly
- [x] `npm audit` — down to 1 finding (dev-server-only, pre-existing, unfixable without dropping react-scripts)
- [x] `CI=true npm run build` compiles successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)